### PR TITLE
Feat 5 pop items

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -8,23 +8,23 @@ class Merchant < ApplicationRecord
   has_many :customers, through: :invoices
 
   def top_five_items
-    items
-          .joins(:transactions)
-          .select('items.*, count(transactions.result) as success_count')
-         
-         .where(transactions: { result: 'success' })
-         .group(:id)
-         .order('success_count desc')
-         .limit(5)
+    # binding.pry
+    items.joins(:transactions)
+    .where(invoices: {status: 2}, transactions: {result: 0})
+    .select("items.id, items.name, sum(invoice_items.quantity * invoice_items.unit_price) as revenue")
+    .group(:id)
+    .order("revenue desc")
+    # .limit(5)
   end
 end
+# items.joins(:transactions).where(invoices: {status: 2}, transactions: {result: 0}).select("items.id, items.name, sum(invoice_items.quantity * invoice_items.unit_price) as revenue").group(:id).order("revenue desc").limit(5)
 
 
-# def top_items
-#   Item.joins(invoices: :transactions)
-#       .where(invoices: {status: 1}, transactions: {result: 1})
-#       .select("items.id, items.name, sum(invoice_items.quantity * invoice_items.unit_price) as revenue")
-#       .group(:id)
-#       .order("revenue desc")
-#       .limit(5)
-# end
+
+# .joins(:transactions)
+# .select('items.*, count(transactions.result) as success_count')
+
+# .where(transactions: { result: 'success' })
+# .group(:id)
+# .order('success_count desc')
+# .limit(5)

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -6,4 +6,25 @@ class Merchant < ApplicationRecord
   has_many :invoices, through: :invoice_items
   has_many :transactions, through: :invoices
   has_many :customers, through: :invoices
+
+  def top_five_items
+    items
+          .joins(:transactions)
+          .select('items.*, count(transactions.result) as success_count')
+         
+         .where(transactions: { result: 'success' })
+         .group(:id)
+         .order('success_count desc')
+         .limit(5)
+  end
 end
+
+
+# def top_items
+#   Item.joins(invoices: :transactions)
+#       .where(invoices: {status: 1}, transactions: {result: 1})
+#       .select("items.id, items.name, sum(invoice_items.quantity * invoice_items.unit_price) as revenue")
+#       .group(:id)
+#       .order("revenue desc")
+#       .limit(5)
+# end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -8,23 +8,11 @@ class Merchant < ApplicationRecord
   has_many :customers, through: :invoices
 
   def top_five_items
-    # binding.pry
     items.joins(:transactions)
-    .where(invoices: {status: 2}, transactions: {result: 0})
+    .where(invoices: {status: 2}, transactions: {result: 'success'})
     .select("items.id, items.name, sum(invoice_items.quantity * invoice_items.unit_price) as revenue")
     .group(:id)
     .order("revenue desc")
-    # .limit(5)
+    .limit(5)
   end
 end
-# items.joins(:transactions).where(invoices: {status: 2}, transactions: {result: 0}).select("items.id, items.name, sum(invoice_items.quantity * invoice_items.unit_price) as revenue").group(:id).order("revenue desc").limit(5)
-
-
-
-# .joins(:transactions)
-# .select('items.*, count(transactions.result) as success_count')
-
-# .where(transactions: { result: 'success' })
-# .group(:id)
-# .order('success_count desc')
-# .limit(5)

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -12,5 +12,11 @@
 
 <div id="top-five-items">
   <h3>Top Items</h3>
-
+  <% @merchant.top_five_items.each do |item| %>
+    <ul>
+      <li><%= link_to item.name, "/merchants/#{@merchant.id}/items/#{item.id}" %> - XXXXX in sales </li>
+    </ul>
+  <% end %>
 </div>
+
+

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -14,7 +14,7 @@
   <h3>Top Items</h3>
   <% @merchant.top_five_items.each do |item| %>
     <ul>
-      <li><%= link_to item.name, "/merchants/#{@merchant.id}/items/#{item.id}" %> - XXXXX in sales </li>
+      <li><%= link_to item.name, "/merchants/#{@merchant.id}/items/#{item.id}" %> - <%=  %> in sales </li>
     </ul>
   <% end %>
 </div>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -14,7 +14,7 @@
   <h3>Top Items</h3>
   <% @merchant.top_five_items.each do |item| %>
     <ul>
-      <li><%= link_to item.name, "/merchants/#{@merchant.id}/items/#{item.id}" %> - <%=  %> in sales </li>
+      <li><%= link_to item.name, "/merchants/#{@merchant.id}/items/#{item.id}" %> - <%= number_to_currency(item.revenue) %> in sales </li>
     </ul>
   <% end %>
 </div>

--- a/app/views/merchant_items/index.html.erb
+++ b/app/views/merchant_items/index.html.erb
@@ -9,3 +9,8 @@
     <p><%= link_to item.name, "/merchants/#{@merchant.id}/items/#{item.id}" %></p>
   </div>
 <% end %>
+
+<div id="top-five-items">
+  <h3>Top Items</h3>
+
+</div>

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -121,12 +121,12 @@ RSpec.describe 'merchant items index page' do
       visit "/merchants/#{merchant_1.id}/items"
 
       within "#top-five-items" do 
-        expect('Bag of Money').to appear_before('Table')
-        expect('Table').to appear_before('Computer')
+        expect('Spatula').to appear_before('Table')
+        expect('Table').to appear_before('Spoon')
+        expect('Spoon').to appear_before('Computer')
         expect('Computer').to appear_before('Knife')
-        expect('Knife').to appear_before('Spatula')
-        expect(page).to have_content('Spatula')
-        expect(page).to_not have_content('Spoon')
+        expect(page).to have_content('Knife')
+        expect(page).to_not have_content('Bag of Money')
       end
     end
   end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -55,5 +55,25 @@ RSpec.describe 'merchant items index page' do
 
         expect(current_path).to eq("/merchants/#{merchant_1.id}/items/new")
     end
+
+    it 'shows the 5 most popular items' do 
+      merchant_1 = Merchant.create!(name: 'Spongebob The Merchant')
+
+      spatula = Item.create!(name: 'Spatula', description: 'It is for cooking', unit_price: 3, merchant_id: merchant_1.id)
+      spoon = Item.create!(name: 'Spoon', description: 'It is for eating ice cream', unit_price: 1, merchant_id: merchant_1.id)
+      knife = Item.create!(name: 'Knife', description: 'It is for slicing bread', unit_price: 5, merchant_id: merchant_1.id)
+      computer = Item.create!(name: 'Computer', description: 'It is for playing games', unit_price: 50, merchant_id: merchant_1.id)
+      table = Item.create!(name: 'Table', description: 'It is for eating at', unit_price: 70, merchant_id: merchant_1.id)
+      bag_of_money = Item.create!(name: 'Bag of Money', description: 'It is for whatever you want', unit_price: 999, merchant_id: merchant_1.id)
+    
+      within "#top-five-items" do 
+        expect('Bag of Money').to appear_before('Table')
+        expect('Table').to appear_before('Computer')
+        expect('Computer').to appear_before('Knife')
+        expect('Knife').to appear_before('Spatula')
+        expect(page).to have_content('Spatula')
+        expect(page).to_not have_content('Spoon')
+      end
+    end
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -56,8 +56,24 @@ RSpec.describe 'merchant items index page' do
         expect(current_path).to eq("/merchants/#{merchant_1.id}/items/new")
     end
 
+
+#     Merchant Items Index: 5 most popular items
+
+      # As a merchant
+      # When I visit my items index page
+      # Then I see the names of the top 5 most popular items ranked by total revenue generated
+      # And I see that each item name links to my merchant item show page for that item
+      # And I see the total revenue generated next to each item name
+
+      # Notes on Revenue Calculation:
+      # - Only invoices with at least one successful transaction should count towards revenue
+      # - Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
+      # - Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)
+
     it 'shows the 5 most popular items' do 
       merchant_1 = Merchant.create!(name: 'Spongebob The Merchant')
+
+      customer_1 = Customer.create!(first_name: 'Somany', last_name: 'Damntests')
 
       spatula = Item.create!(name: 'Spatula', description: 'It is for cooking', unit_price: 3, merchant_id: merchant_1.id)
       spoon = Item.create!(name: 'Spoon', description: 'It is for eating ice cream', unit_price: 1, merchant_id: merchant_1.id)
@@ -65,7 +81,23 @@ RSpec.describe 'merchant items index page' do
       computer = Item.create!(name: 'Computer', description: 'It is for playing games', unit_price: 50, merchant_id: merchant_1.id)
       table = Item.create!(name: 'Table', description: 'It is for eating at', unit_price: 70, merchant_id: merchant_1.id)
       bag_of_money = Item.create!(name: 'Bag of Money', description: 'It is for whatever you want', unit_price: 999, merchant_id: merchant_1.id)
-    
+
+      invoice_1 = Invoice.create!(customer_id: customer_1.id, status: 2)
+
+      transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '983475', credit_card_expiration_date: nil, result: 0)
+      transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '345', credit_card_expiration_date: nil, result: 1)
+      transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '34657865', credit_card_expiration_date: nil, result: 0)
+      transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '78965367', credit_card_expiration_date: nil, result: 0)
+
+      InvoiceItem.create!(item_id: spatula.id, invoice_id: invoice_1.id, quantity: 5, unit_price: 23, status: 2)
+      InvoiceItem.create!(item_id: spoon.id, invoice_id: invoice_1.id, quantity: 3, unit_price: 2345, status: 2)
+      InvoiceItem.create!(item_id: knife.id, invoice_id: invoice_1.id, quantity: 2, unit_price: 654, status: 2)
+      InvoiceItem.create!(item_id: computer.id, invoice_id: invoice_1.id, quantity: 4, unit_price: 876, status: 2)
+      InvoiceItem.create!(item_id: table.id, invoice_id: invoice_1.id, quantity: 3, unit_price: 543, status: 2)
+      InvoiceItem.create!(item_id: bag_of_money.id, invoice_id: invoice_1.id, quantity: 4, unit_price: 352, status: 2)
+
+      visit "/merchants/#{merchant_1.id}/items"
+
       within "#top-five-items" do 
         expect('Bag of Money').to appear_before('Table')
         expect('Table').to appear_before('Computer')

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -72,8 +72,11 @@ RSpec.describe 'merchant items index page' do
 
     it 'shows the 5 most popular items' do 
       merchant_1 = Merchant.create!(name: 'Spongebob The Merchant')
+      merchant_2 = Merchant.create!(name: 'Sandy The Squirrel Merchant')
 
       customer_1 = Customer.create!(first_name: 'Somany', last_name: 'Damntests')
+      customer_2 = Customer.create!(first_name: 'Keeling', last_name: 'Mesoftly')
+      customer_3 = Customer.create!(first_name: 'Withis', last_name: 'Words')
 
       spatula = Item.create!(name: 'Spatula', description: 'It is for cooking', unit_price: 3, merchant_id: merchant_1.id)
       spoon = Item.create!(name: 'Spoon', description: 'It is for eating ice cream', unit_price: 1, merchant_id: merchant_1.id)
@@ -81,20 +84,39 @@ RSpec.describe 'merchant items index page' do
       computer = Item.create!(name: 'Computer', description: 'It is for playing games', unit_price: 50, merchant_id: merchant_1.id)
       table = Item.create!(name: 'Table', description: 'It is for eating at', unit_price: 70, merchant_id: merchant_1.id)
       bag_of_money = Item.create!(name: 'Bag of Money', description: 'It is for whatever you want', unit_price: 999, merchant_id: merchant_1.id)
+      wooden_number_seven = Item.create!(name: 'Decorative Wood 7', description: 'It is a piece of wood shaped like a 7', unit_price: 400, merchant_id: merchant_1.id)
+      jacks = Item.create!(name: 'Bag of Jacks', description: 'It is for playing Jacks', unit_price: 3, merchant_id: merchant_2.id)
 
       invoice_1 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_2 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_3 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_4 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_5 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_6 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_7 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_8 = Invoice.create!(customer_id: customer_1.id, status: 1)
 
-      transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '983475', credit_card_expiration_date: nil, result: 0)
-      transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '345', credit_card_expiration_date: nil, result: 1)
-      transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '34657865', credit_card_expiration_date: nil, result: 0)
-      transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '78965367', credit_card_expiration_date: nil, result: 0)
+      transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '983475', credit_card_expiration_date: nil, result: 'success')
+      transaction_2 = Transaction.create!(invoice_id: invoice_2.id, credit_card_number: '345', credit_card_expiration_date: nil, result: 'success')
+      transaction_3 = Transaction.create!(invoice_id: invoice_3.id, credit_card_number: '34657865', credit_card_expiration_date: nil, result: 'success')
+      transaction_4 = Transaction.create!(invoice_id: invoice_4.id, credit_card_number: '3456546', credit_card_expiration_date: nil, result: 'success')
+      transaction_5 = Transaction.create!(invoice_id: invoice_5.id, credit_card_number: '234234', credit_card_expiration_date: nil, result: 'success')
+      transaction_6 = Transaction.create!(invoice_id: invoice_6.id, credit_card_number: '6578', credit_card_expiration_date: nil, result: 'success')
+      transaction_7 = Transaction.create!(invoice_id: invoice_7.id, credit_card_number: '9789', credit_card_expiration_date: nil, result: 'success')
+      transaction_8 = Transaction.create!(invoice_id: invoice_8.id, credit_card_number: '3456', credit_card_expiration_date: nil, result: 'failed')
 
-      InvoiceItem.create!(item_id: spatula.id, invoice_id: invoice_1.id, quantity: 5, unit_price: 23, status: 2)
-      InvoiceItem.create!(item_id: spoon.id, invoice_id: invoice_1.id, quantity: 3, unit_price: 2345, status: 2)
-      InvoiceItem.create!(item_id: knife.id, invoice_id: invoice_1.id, quantity: 2, unit_price: 654, status: 2)
-      InvoiceItem.create!(item_id: computer.id, invoice_id: invoice_1.id, quantity: 4, unit_price: 876, status: 2)
-      InvoiceItem.create!(item_id: table.id, invoice_id: invoice_1.id, quantity: 3, unit_price: 543, status: 2)
-      InvoiceItem.create!(item_id: bag_of_money.id, invoice_id: invoice_1.id, quantity: 4, unit_price: 352, status: 2)
+      invoice_item_1 = InvoiceItem.create!(item_id: spatula.id, invoice_id: invoice_1.id, quantity: 5, unit_price: 2, status: 2)
+      invoice_item_2 = InvoiceItem.create!(item_id: spoon.id, invoice_id: invoice_1.id, quantity: 3, unit_price: 3, status: 2)
+      invoice_item_3 = InvoiceItem.create!(item_id: knife.id, invoice_id: invoice_2.id, quantity: 2, unit_price: 1, status: 2)
+      invoice_item_4 = InvoiceItem.create!(item_id: computer.id, invoice_id: invoice_2.id, quantity: 4, unit_price: 2, status: 2)
+      invoice_item_5 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_3.id, quantity: 3, unit_price: 3, status: 2)
+      invoice_item_7 = InvoiceItem.create!(item_id: bag_of_money.id, invoice_id: invoice_3.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_8 = InvoiceItem.create!(item_id: wooden_number_seven.id, invoice_id: invoice_4.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_9 = InvoiceItem.create!(item_id: knife.id, invoice_id: invoice_4.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_10 = InvoiceItem.create!(item_id: spatula.id, invoice_id: invoice_5.id, quantity: 3, unit_price: 4, status: 2)
+      invoice_item_11 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_6.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_12 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_7.id, quantity: 2, unit_price: 3, status: 2)
+      invoice_item_13 = InvoiceItem.create!(item_id: jacks.id, invoice_id: invoice_8.id, quantity: 4, unit_price: 1, status: 2)
 
       visit "/merchants/#{merchant_1.id}/items"
 

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -174,5 +174,62 @@ RSpec.describe 'merchant items index page' do
         expect(page).to have_link('Knife')
       end
     end
+
+    it 'the top 5 items link will take you to its show page for that merchant' do 
+      merchant_1 = Merchant.create!(name: 'Spongebob The Merchant')
+      merchant_2 = Merchant.create!(name: 'Sandy The Squirrel Merchant')
+
+      customer_1 = Customer.create!(first_name: 'Somany', last_name: 'Damntests')
+      customer_2 = Customer.create!(first_name: 'Keeling', last_name: 'Mesoftly')
+      customer_3 = Customer.create!(first_name: 'Withis', last_name: 'Words')
+
+      spatula = Item.create!(name: 'Spatula', description: 'It is for cooking', unit_price: 3, merchant_id: merchant_1.id)
+      spoon = Item.create!(name: 'Spoon', description: 'It is for eating ice cream', unit_price: 1, merchant_id: merchant_1.id)
+      knife = Item.create!(name: 'Knife', description: 'It is for slicing bread', unit_price: 5, merchant_id: merchant_1.id)
+      computer = Item.create!(name: 'Computer', description: 'It is for playing games', unit_price: 50, merchant_id: merchant_1.id)
+      table = Item.create!(name: 'Table', description: 'It is for eating at', unit_price: 70, merchant_id: merchant_1.id)
+      bag_of_money = Item.create!(name: 'Bag of Money', description: 'It is for whatever you want', unit_price: 999, merchant_id: merchant_1.id)
+      wooden_number_seven = Item.create!(name: 'Decorative Wood 7', description: 'It is a piece of wood shaped like a 7', unit_price: 400, merchant_id: merchant_1.id)
+      jacks = Item.create!(name: 'Bag of Jacks', description: 'It is for playing Jacks', unit_price: 3, merchant_id: merchant_2.id)
+
+      invoice_1 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_2 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_3 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_4 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_5 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_6 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_7 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_8 = Invoice.create!(customer_id: customer_1.id, status: 1)
+
+      transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '983475', credit_card_expiration_date: nil, result: 'success')
+      transaction_2 = Transaction.create!(invoice_id: invoice_2.id, credit_card_number: '345', credit_card_expiration_date: nil, result: 'success')
+      transaction_3 = Transaction.create!(invoice_id: invoice_3.id, credit_card_number: '34657865', credit_card_expiration_date: nil, result: 'success')
+      transaction_4 = Transaction.create!(invoice_id: invoice_4.id, credit_card_number: '3456546', credit_card_expiration_date: nil, result: 'success')
+      transaction_5 = Transaction.create!(invoice_id: invoice_5.id, credit_card_number: '234234', credit_card_expiration_date: nil, result: 'success')
+      transaction_6 = Transaction.create!(invoice_id: invoice_6.id, credit_card_number: '6578', credit_card_expiration_date: nil, result: 'success')
+      transaction_7 = Transaction.create!(invoice_id: invoice_7.id, credit_card_number: '9789', credit_card_expiration_date: nil, result: 'success')
+      transaction_8 = Transaction.create!(invoice_id: invoice_8.id, credit_card_number: '3456', credit_card_expiration_date: nil, result: 'failed')
+
+      invoice_item_1 = InvoiceItem.create!(item_id: spatula.id, invoice_id: invoice_1.id, quantity: 5, unit_price: 2, status: 2)
+      invoice_item_2 = InvoiceItem.create!(item_id: spoon.id, invoice_id: invoice_1.id, quantity: 3, unit_price: 3, status: 2)
+      invoice_item_3 = InvoiceItem.create!(item_id: knife.id, invoice_id: invoice_2.id, quantity: 2, unit_price: 1, status: 2)
+      invoice_item_4 = InvoiceItem.create!(item_id: computer.id, invoice_id: invoice_2.id, quantity: 4, unit_price: 2, status: 2)
+      invoice_item_5 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_3.id, quantity: 3, unit_price: 3, status: 2)
+      invoice_item_7 = InvoiceItem.create!(item_id: bag_of_money.id, invoice_id: invoice_3.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_8 = InvoiceItem.create!(item_id: wooden_number_seven.id, invoice_id: invoice_4.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_9 = InvoiceItem.create!(item_id: knife.id, invoice_id: invoice_4.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_10 = InvoiceItem.create!(item_id: spatula.id, invoice_id: invoice_5.id, quantity: 3, unit_price: 4, status: 2)
+      invoice_item_11 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_6.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_12 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_7.id, quantity: 2, unit_price: 3, status: 2)
+      invoice_item_13 = InvoiceItem.create!(item_id: jacks.id, invoice_id: invoice_8.id, quantity: 4, unit_price: 1, status: 2)
+
+      visit "/merchants/#{merchant_1.id}/items"
+
+      within "#top-five-items" do 
+        click_on 'Spatula'
+
+        expect(current_path).to eq("/merchants/#{@merchant_1.id}/items/#{spatula.id}")
+      end
+    end
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe 'merchant items index page' do
       within "#top-five-items" do 
         click_on 'Spatula'
 
-        expect(current_path).to eq("/merchants/#{@merchant_1.id}/items/#{spatula.id}")
+        expect(current_path).to eq("/merchants/#{merchant_1.id}/items/#{spatula.id}")
       end
     end
   end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -231,5 +231,64 @@ RSpec.describe 'merchant items index page' do
         expect(current_path).to eq("/merchants/#{merchant_1.id}/items/#{spatula.id}")
       end
     end
+
+    it 'shows the revenue for each of the top 5 items' do 
+      merchant_1 = Merchant.create!(name: 'Spongebob The Merchant')
+      merchant_2 = Merchant.create!(name: 'Sandy The Squirrel Merchant')
+
+      customer_1 = Customer.create!(first_name: 'Somany', last_name: 'Damntests')
+      customer_2 = Customer.create!(first_name: 'Keeling', last_name: 'Mesoftly')
+      customer_3 = Customer.create!(first_name: 'Withis', last_name: 'Words')
+
+      spatula = Item.create!(name: 'Spatula', description: 'It is for cooking', unit_price: 3, merchant_id: merchant_1.id)
+      spoon = Item.create!(name: 'Spoon', description: 'It is for eating ice cream', unit_price: 1, merchant_id: merchant_1.id)
+      knife = Item.create!(name: 'Knife', description: 'It is for slicing bread', unit_price: 5, merchant_id: merchant_1.id)
+      computer = Item.create!(name: 'Computer', description: 'It is for playing games', unit_price: 50, merchant_id: merchant_1.id)
+      table = Item.create!(name: 'Table', description: 'It is for eating at', unit_price: 70, merchant_id: merchant_1.id)
+      bag_of_money = Item.create!(name: 'Bag of Money', description: 'It is for whatever you want', unit_price: 999, merchant_id: merchant_1.id)
+      wooden_number_seven = Item.create!(name: 'Decorative Wood 7', description: 'It is a piece of wood shaped like a 7', unit_price: 400, merchant_id: merchant_1.id)
+      jacks = Item.create!(name: 'Bag of Jacks', description: 'It is for playing Jacks', unit_price: 3, merchant_id: merchant_2.id)
+
+      invoice_1 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_2 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_3 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_4 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_5 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_6 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_7 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_8 = Invoice.create!(customer_id: customer_1.id, status: 1)
+
+      transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '983475', credit_card_expiration_date: nil, result: 'success')
+      transaction_2 = Transaction.create!(invoice_id: invoice_2.id, credit_card_number: '345', credit_card_expiration_date: nil, result: 'success')
+      transaction_3 = Transaction.create!(invoice_id: invoice_3.id, credit_card_number: '34657865', credit_card_expiration_date: nil, result: 'success')
+      transaction_4 = Transaction.create!(invoice_id: invoice_4.id, credit_card_number: '3456546', credit_card_expiration_date: nil, result: 'success')
+      transaction_5 = Transaction.create!(invoice_id: invoice_5.id, credit_card_number: '234234', credit_card_expiration_date: nil, result: 'success')
+      transaction_6 = Transaction.create!(invoice_id: invoice_6.id, credit_card_number: '6578', credit_card_expiration_date: nil, result: 'success')
+      transaction_7 = Transaction.create!(invoice_id: invoice_7.id, credit_card_number: '9789', credit_card_expiration_date: nil, result: 'success')
+      transaction_8 = Transaction.create!(invoice_id: invoice_8.id, credit_card_number: '3456', credit_card_expiration_date: nil, result: 'failed')
+
+      invoice_item_1 = InvoiceItem.create!(item_id: spatula.id, invoice_id: invoice_1.id, quantity: 5, unit_price: 2, status: 2)
+      invoice_item_2 = InvoiceItem.create!(item_id: spoon.id, invoice_id: invoice_1.id, quantity: 3, unit_price: 3, status: 2)
+      invoice_item_3 = InvoiceItem.create!(item_id: knife.id, invoice_id: invoice_2.id, quantity: 2, unit_price: 1, status: 2)
+      invoice_item_4 = InvoiceItem.create!(item_id: computer.id, invoice_id: invoice_2.id, quantity: 4, unit_price: 2, status: 2)
+      invoice_item_5 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_3.id, quantity: 3, unit_price: 3, status: 2)
+      invoice_item_7 = InvoiceItem.create!(item_id: bag_of_money.id, invoice_id: invoice_3.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_8 = InvoiceItem.create!(item_id: wooden_number_seven.id, invoice_id: invoice_4.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_9 = InvoiceItem.create!(item_id: knife.id, invoice_id: invoice_4.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_10 = InvoiceItem.create!(item_id: spatula.id, invoice_id: invoice_5.id, quantity: 3, unit_price: 4, status: 2)
+      invoice_item_11 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_6.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_12 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_7.id, quantity: 2, unit_price: 3, status: 2)
+      invoice_item_13 = InvoiceItem.create!(item_id: jacks.id, invoice_id: invoice_8.id, quantity: 4, unit_price: 1, status: 2)
+
+      visit "/merchants/#{merchant_1.id}/items"
+
+      within "#top-five-items" do 
+        expect(page).to have_content('$22.00')
+        expect(page).to have_content('$19.00')
+        expect(page).to have_content('$9.00')
+        expect(page).to have_content('$8.00')
+        expect(page).to have_content('$6.00')
+      end
+    end
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -56,20 +56,6 @@ RSpec.describe 'merchant items index page' do
         expect(current_path).to eq("/merchants/#{merchant_1.id}/items/new")
     end
 
-
-#     Merchant Items Index: 5 most popular items
-
-      # As a merchant
-      # When I visit my items index page
-      # Then I see the names of the top 5 most popular items ranked by total revenue generated
-      # And I see that each item name links to my merchant item show page for that item
-      # And I see the total revenue generated next to each item name
-
-      # Notes on Revenue Calculation:
-      # - Only invoices with at least one successful transaction should count towards revenue
-      # - Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
-      # - Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)
-
     it 'shows the 5 most popular items' do 
       merchant_1 = Merchant.create!(name: 'Spongebob The Merchant')
       merchant_2 = Merchant.create!(name: 'Sandy The Squirrel Merchant')
@@ -127,6 +113,65 @@ RSpec.describe 'merchant items index page' do
         expect('Computer').to appear_before('Knife')
         expect(page).to have_content('Knife')
         expect(page).to_not have_content('Bag of Money')
+      end
+    end
+
+    it 'the top 5 items has a link to each items merchant item show page' do 
+      merchant_1 = Merchant.create!(name: 'Spongebob The Merchant')
+      merchant_2 = Merchant.create!(name: 'Sandy The Squirrel Merchant')
+
+      customer_1 = Customer.create!(first_name: 'Somany', last_name: 'Damntests')
+      customer_2 = Customer.create!(first_name: 'Keeling', last_name: 'Mesoftly')
+      customer_3 = Customer.create!(first_name: 'Withis', last_name: 'Words')
+
+      spatula = Item.create!(name: 'Spatula', description: 'It is for cooking', unit_price: 3, merchant_id: merchant_1.id)
+      spoon = Item.create!(name: 'Spoon', description: 'It is for eating ice cream', unit_price: 1, merchant_id: merchant_1.id)
+      knife = Item.create!(name: 'Knife', description: 'It is for slicing bread', unit_price: 5, merchant_id: merchant_1.id)
+      computer = Item.create!(name: 'Computer', description: 'It is for playing games', unit_price: 50, merchant_id: merchant_1.id)
+      table = Item.create!(name: 'Table', description: 'It is for eating at', unit_price: 70, merchant_id: merchant_1.id)
+      bag_of_money = Item.create!(name: 'Bag of Money', description: 'It is for whatever you want', unit_price: 999, merchant_id: merchant_1.id)
+      wooden_number_seven = Item.create!(name: 'Decorative Wood 7', description: 'It is a piece of wood shaped like a 7', unit_price: 400, merchant_id: merchant_1.id)
+      jacks = Item.create!(name: 'Bag of Jacks', description: 'It is for playing Jacks', unit_price: 3, merchant_id: merchant_2.id)
+
+      invoice_1 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_2 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_3 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_4 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_5 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_6 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_7 = Invoice.create!(customer_id: customer_1.id, status: 2)
+      invoice_8 = Invoice.create!(customer_id: customer_1.id, status: 1)
+
+      transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '983475', credit_card_expiration_date: nil, result: 'success')
+      transaction_2 = Transaction.create!(invoice_id: invoice_2.id, credit_card_number: '345', credit_card_expiration_date: nil, result: 'success')
+      transaction_3 = Transaction.create!(invoice_id: invoice_3.id, credit_card_number: '34657865', credit_card_expiration_date: nil, result: 'success')
+      transaction_4 = Transaction.create!(invoice_id: invoice_4.id, credit_card_number: '3456546', credit_card_expiration_date: nil, result: 'success')
+      transaction_5 = Transaction.create!(invoice_id: invoice_5.id, credit_card_number: '234234', credit_card_expiration_date: nil, result: 'success')
+      transaction_6 = Transaction.create!(invoice_id: invoice_6.id, credit_card_number: '6578', credit_card_expiration_date: nil, result: 'success')
+      transaction_7 = Transaction.create!(invoice_id: invoice_7.id, credit_card_number: '9789', credit_card_expiration_date: nil, result: 'success')
+      transaction_8 = Transaction.create!(invoice_id: invoice_8.id, credit_card_number: '3456', credit_card_expiration_date: nil, result: 'failed')
+
+      invoice_item_1 = InvoiceItem.create!(item_id: spatula.id, invoice_id: invoice_1.id, quantity: 5, unit_price: 2, status: 2)
+      invoice_item_2 = InvoiceItem.create!(item_id: spoon.id, invoice_id: invoice_1.id, quantity: 3, unit_price: 3, status: 2)
+      invoice_item_3 = InvoiceItem.create!(item_id: knife.id, invoice_id: invoice_2.id, quantity: 2, unit_price: 1, status: 2)
+      invoice_item_4 = InvoiceItem.create!(item_id: computer.id, invoice_id: invoice_2.id, quantity: 4, unit_price: 2, status: 2)
+      invoice_item_5 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_3.id, quantity: 3, unit_price: 3, status: 2)
+      invoice_item_7 = InvoiceItem.create!(item_id: bag_of_money.id, invoice_id: invoice_3.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_8 = InvoiceItem.create!(item_id: wooden_number_seven.id, invoice_id: invoice_4.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_9 = InvoiceItem.create!(item_id: knife.id, invoice_id: invoice_4.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_10 = InvoiceItem.create!(item_id: spatula.id, invoice_id: invoice_5.id, quantity: 3, unit_price: 4, status: 2)
+      invoice_item_11 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_6.id, quantity: 4, unit_price: 1, status: 2)
+      invoice_item_12 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_7.id, quantity: 2, unit_price: 3, status: 2)
+      invoice_item_13 = InvoiceItem.create!(item_id: jacks.id, invoice_id: invoice_8.id, quantity: 4, unit_price: 1, status: 2)
+
+      visit "/merchants/#{merchant_1.id}/items"
+
+      within "#top-five-items" do 
+        expect(page).to have_link('Spatula')
+        expect(page).to have_link('Table')
+        expect(page).to have_link('Spoon')
+        expect(page).to have_link('Computer')
+        expect(page).to have_link('Knife')
       end
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Merchant do
         invoice_item_11 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_6.id, quantity: 4, unit_price: 1, status: 2)
         invoice_item_12 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_7.id, quantity: 2, unit_price: 3, status: 2)
         invoice_item_13 = InvoiceItem.create!(item_id: jacks.id, invoice_id: invoice_8.id, quantity: 4, unit_price: 1, status: 2)
-
+        binding.pry
         expect(merchant_1.top_five_items).to eq([spatula, table, spoon, computer, knife])
       end
     end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -11,5 +11,11 @@ RSpec.describe Merchant do
     it { should have_many(:invoices).through(:invoice_items) }
     it { should have_many(:transactions).through(:invoices) }
     it { should have_many(:customers).through(:invoices) }
+
+    def top_five_items
+      
+
+      
+    end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -11,11 +11,59 @@ RSpec.describe Merchant do
     it { should have_many(:invoices).through(:invoice_items) }
     it { should have_many(:transactions).through(:invoices) }
     it { should have_many(:customers).through(:invoices) }
+  end 
 
-    def top_five_items
-      
+    describe 'instance methods' do 
+      it 'calculates the top 5 most popular items by total revenue generated' do 
 
-      
+        merchant_1 = Merchant.create!(name: 'Spongebob The Merchant')
+        merchant_2 = Merchant.create!(name: 'Sandy The Squirrel Merchant')
+
+        customer_1 = Customer.create!(first_name: 'Somany', last_name: 'Damntests')
+        customer_2 = Customer.create!(first_name: 'Keeling', last_name: 'Mesoftly')
+        customer_3 = Customer.create!(first_name: 'Withis', last_name: 'Words')
+
+        spatula = Item.create!(name: 'Spatula', description: 'It is for cooking', unit_price: 3, merchant_id: merchant_1.id)
+        spoon = Item.create!(name: 'Spoon', description: 'It is for eating ice cream', unit_price: 1, merchant_id: merchant_1.id)
+        knife = Item.create!(name: 'Knife', description: 'It is for slicing bread', unit_price: 5, merchant_id: merchant_1.id)
+        computer = Item.create!(name: 'Computer', description: 'It is for playing games', unit_price: 50, merchant_id: merchant_1.id)
+        table = Item.create!(name: 'Table', description: 'It is for eating at', unit_price: 70, merchant_id: merchant_1.id)
+        bag_of_money = Item.create!(name: 'Bag of Money', description: 'It is for whatever you want', unit_price: 999, merchant_id: merchant_1.id)
+        wooden_number_seven = Item.create!(name: 'Decorative Wood 7', description: 'It is a piece of wood shaped like a 7', unit_price: 400, merchant_id: merchant_1.id)
+        jacks = Item.create!(name: 'Bag of Jacks', description: 'It is for playing Jacks', unit_price: 3, merchant_id: merchant_2.id)
+
+        invoice_1 = Invoice.create!(customer_id: customer_1.id, status: 2)
+        invoice_2 = Invoice.create!(customer_id: customer_1.id, status: 2)
+        invoice_3 = Invoice.create!(customer_id: customer_1.id, status: 2)
+        invoice_4 = Invoice.create!(customer_id: customer_1.id, status: 2)
+        invoice_5 = Invoice.create!(customer_id: customer_1.id, status: 2)
+        invoice_6 = Invoice.create!(customer_id: customer_1.id, status: 2)
+        invoice_7 = Invoice.create!(customer_id: customer_1.id, status: 2)
+        invoice_8 = Invoice.create!(customer_id: customer_1.id, status: 1)
+
+        transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '983475', credit_card_expiration_date: nil, result: 0)
+        transaction_2 = Transaction.create!(invoice_id: invoice_2.id, credit_card_number: '345', credit_card_expiration_date: nil, result: 1)
+        transaction_3 = Transaction.create!(invoice_id: invoice_3.id, credit_card_number: '34657865', credit_card_expiration_date: nil, result: 1)
+        transaction_4 = Transaction.create!(invoice_id: invoice_4.id, credit_card_number: '3456546', credit_card_expiration_date: nil, result: 1)
+        transaction_5 = Transaction.create!(invoice_id: invoice_5.id, credit_card_number: '234234', credit_card_expiration_date: nil, result: 0)
+        transaction_6 = Transaction.create!(invoice_id: invoice_6.id, credit_card_number: '6578', credit_card_expiration_date: nil, result: 0)
+        transaction_7 = Transaction.create!(invoice_id: invoice_7.id, credit_card_number: '9789', credit_card_expiration_date: nil, result: 0)
+        transaction_8 = Transaction.create!(invoice_id: invoice_8.id, credit_card_number: '3456', credit_card_expiration_date: nil, result: 0)
+
+        invoice_item_1 = InvoiceItem.create!(item_id: spatula.id, invoice_id: invoice_1.id, quantity: 5, unit_price: 2, status: 2)
+        invoice_item_2 = InvoiceItem.create!(item_id: spoon.id, invoice_id: invoice_1.id, quantity: 3, unit_price: 3, status: 2)
+        invoice_item_3 = InvoiceItem.create!(item_id: knife.id, invoice_id: invoice_2.id, quantity: 2, unit_price: 1, status: 2)
+        invoice_item_4 = InvoiceItem.create!(item_id: computer.id, invoice_id: invoice_2.id, quantity: 4, unit_price: 2, status: 2)
+        invoice_item_5 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_3.id, quantity: 3, unit_price: 3, status: 2)
+        invoice_item_7 = InvoiceItem.create!(item_id: bag_of_money.id, invoice_id: invoice_3.id, quantity: 4, unit_price: 1, status: 2)
+        invoice_item_8 = InvoiceItem.create!(item_id: wooden_number_seven.id, invoice_id: invoice_4.id, quantity: 4, unit_price: 1, status: 2)
+        invoice_item_9 = InvoiceItem.create!(item_id: knife.id, invoice_id: invoice_4.id, quantity: 4, unit_price: 1, status: 2)
+        invoice_item_10 = InvoiceItem.create!(item_id: spatula.id, invoice_id: invoice_5.id, quantity: 3, unit_price: 4, status: 2)
+        invoice_item_11 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_6.id, quantity: 4, unit_price: 1, status: 2) #4
+        invoice_item_12 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_7.id, quantity: 2, unit_price: 3, status: 2) #6
+        invoice_item_13 = InvoiceItem.create!(item_id: jacks.id, invoice_id: invoice_8.id, quantity: 4, unit_price: 1, status: 2) #4
+
+        expect(merchant_1.top_five_items).to eq([])
+      end
     end
-  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -41,14 +41,14 @@ RSpec.describe Merchant do
         invoice_7 = Invoice.create!(customer_id: customer_1.id, status: 2)
         invoice_8 = Invoice.create!(customer_id: customer_1.id, status: 1)
 
-        transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '983475', credit_card_expiration_date: nil, result: 0)
-        transaction_2 = Transaction.create!(invoice_id: invoice_2.id, credit_card_number: '345', credit_card_expiration_date: nil, result: 1)
-        transaction_3 = Transaction.create!(invoice_id: invoice_3.id, credit_card_number: '34657865', credit_card_expiration_date: nil, result: 1)
-        transaction_4 = Transaction.create!(invoice_id: invoice_4.id, credit_card_number: '3456546', credit_card_expiration_date: nil, result: 1)
-        transaction_5 = Transaction.create!(invoice_id: invoice_5.id, credit_card_number: '234234', credit_card_expiration_date: nil, result: 0)
-        transaction_6 = Transaction.create!(invoice_id: invoice_6.id, credit_card_number: '6578', credit_card_expiration_date: nil, result: 0)
-        transaction_7 = Transaction.create!(invoice_id: invoice_7.id, credit_card_number: '9789', credit_card_expiration_date: nil, result: 0)
-        transaction_8 = Transaction.create!(invoice_id: invoice_8.id, credit_card_number: '3456', credit_card_expiration_date: nil, result: 0)
+        transaction_1 = Transaction.create!(invoice_id: invoice_1.id, credit_card_number: '983475', credit_card_expiration_date: nil, result: 'success')
+        transaction_2 = Transaction.create!(invoice_id: invoice_2.id, credit_card_number: '345', credit_card_expiration_date: nil, result: 'success')
+        transaction_3 = Transaction.create!(invoice_id: invoice_3.id, credit_card_number: '34657865', credit_card_expiration_date: nil, result: 'success')
+        transaction_4 = Transaction.create!(invoice_id: invoice_4.id, credit_card_number: '3456546', credit_card_expiration_date: nil, result: 'success')
+        transaction_5 = Transaction.create!(invoice_id: invoice_5.id, credit_card_number: '234234', credit_card_expiration_date: nil, result: 'success')
+        transaction_6 = Transaction.create!(invoice_id: invoice_6.id, credit_card_number: '6578', credit_card_expiration_date: nil, result: 'success')
+        transaction_7 = Transaction.create!(invoice_id: invoice_7.id, credit_card_number: '9789', credit_card_expiration_date: nil, result: 'success')
+        transaction_8 = Transaction.create!(invoice_id: invoice_8.id, credit_card_number: '3456', credit_card_expiration_date: nil, result: 'failed')
 
         invoice_item_1 = InvoiceItem.create!(item_id: spatula.id, invoice_id: invoice_1.id, quantity: 5, unit_price: 2, status: 2)
         invoice_item_2 = InvoiceItem.create!(item_id: spoon.id, invoice_id: invoice_1.id, quantity: 3, unit_price: 3, status: 2)
@@ -63,7 +63,7 @@ RSpec.describe Merchant do
         invoice_item_12 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_7.id, quantity: 2, unit_price: 3, status: 2) #6
         invoice_item_13 = InvoiceItem.create!(item_id: jacks.id, invoice_id: invoice_8.id, quantity: 4, unit_price: 1, status: 2) #4
 
-        expect(merchant_1.top_five_items).to eq([])
+        expect(merchant_1.top_five_items).to eq([spatula, table, spoon, computer, knife])
       end
     end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe Merchant do
         invoice_item_8 = InvoiceItem.create!(item_id: wooden_number_seven.id, invoice_id: invoice_4.id, quantity: 4, unit_price: 1, status: 2)
         invoice_item_9 = InvoiceItem.create!(item_id: knife.id, invoice_id: invoice_4.id, quantity: 4, unit_price: 1, status: 2)
         invoice_item_10 = InvoiceItem.create!(item_id: spatula.id, invoice_id: invoice_5.id, quantity: 3, unit_price: 4, status: 2)
-        invoice_item_11 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_6.id, quantity: 4, unit_price: 1, status: 2) #4
-        invoice_item_12 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_7.id, quantity: 2, unit_price: 3, status: 2) #6
-        invoice_item_13 = InvoiceItem.create!(item_id: jacks.id, invoice_id: invoice_8.id, quantity: 4, unit_price: 1, status: 2) #4
+        invoice_item_11 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_6.id, quantity: 4, unit_price: 1, status: 2)
+        invoice_item_12 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_7.id, quantity: 2, unit_price: 3, status: 2)
+        invoice_item_13 = InvoiceItem.create!(item_id: jacks.id, invoice_id: invoice_8.id, quantity: 4, unit_price: 1, status: 2)
 
         expect(merchant_1.top_five_items).to eq([spatula, table, spoon, computer, knife])
       end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Merchant do
         invoice_item_11 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_6.id, quantity: 4, unit_price: 1, status: 2)
         invoice_item_12 = InvoiceItem.create!(item_id: table.id, invoice_id: invoice_7.id, quantity: 2, unit_price: 3, status: 2)
         invoice_item_13 = InvoiceItem.create!(item_id: jacks.id, invoice_id: invoice_8.id, quantity: 4, unit_price: 1, status: 2)
-        binding.pry
+
         expect(merchant_1.top_five_items).to eq([spatula, table, spoon, computer, knife])
       end
     end


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Problem/feature

_What problem are you trying to solve?_
Merchant Items Index: 5 most popular items

As a merchant
When I visit my items index page
Then I see the names of the top 5 most popular items ranked by total revenue generated
And I see that each item name links to my merchant item show page for that item
And I see the total revenue generated next to each item name

Notes on Revenue Calculation:
- Only invoices with at least one successful transaction should count towards revenue
- Revenue for an invoice should be calculated as the sum of the revenue of all invoice items
- Revenue for an invoice item should be calculated as the invoice item unit price multiplied by the quantity (do not use the item unit price)


## Other changes (e.g. bug fixes, UI tweaks, small refactors)

## Checklist
- [X] Code compiles correctly
- [ ] Tests for the changes have been added (for bug fixes/features)
- [X] All tests passing
- [ ] Extended the README / documentation, if necessary